### PR TITLE
ajout zone UTC dans le jdbc de connexion à la base

### DIFF
--- a/parkingsystem/src/main/java/com/parkit/parkingsystem/config/DataBaseConfig.java
+++ b/parkingsystem/src/main/java/com/parkit/parkingsystem/config/DataBaseConfig.java
@@ -13,7 +13,7 @@ public class DataBaseConfig {
         logger.info("Create DB connection");
         Class.forName("com.mysql.cj.jdbc.Driver");
         return DriverManager.getConnection(
-                "jdbc:mysql://localhost:3306/prod","root","rootroot");
+                "jdbc:mysql://localhost:3306/prod?zeroDateTimeBehavior=CONVERT_TO_NULL&serverTimezone=UTC","root","rootroot");
     }
 
     public void closeConnection(Connection con){


### PR DESCRIPTION
Spécification zone UTC ajouté directement dans le jdbc de connection à la bdd dans le package config, fichier DataBaseConfig. la ligne est la suivante : ?zeroDateTimeBehavior=CONVERT_TO_NULL&serverTimezone=UTC. L16
